### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To connect to the server seeded with that exported data, use one of these templa
     "ldapConfig" : {
         "provider" : "iserv-idm",
         "url" : "ldap://127.0.0.1:389",
-        "rootPath" : "dc=example,dc=org",
+        "rootPath" : "dc=de,dc=example,dc=org",
         "searchUser" : "cn=admin,dc=example,dc=org",
         "searchUserPassword" : "U2FsdGVkX18OoIinJA2yeskAPGLFqcb0ArdCNoouRrY=",
         "active" : true

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To connect to the server seeded with that exported data, use one of these templa
 		}
 	},
 	"type": "ldap",
-	"alias": "LDAP Integration",
+	"alias": "LDAP Integration"
 }
 ```
 


### PR DESCRIPTION
Adds `dc=de` to the `rootPath` attribute of the `iserv-idm` config to avoid failing syncs, because the base node `dc=example,dc=org` is an organization and would otherwise be discovered as a school.